### PR TITLE
[AS-2597] docs: add localized app-sdk tutorial guides

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,136 @@
+# Channel App チュートリアル — TypeScript
+
+[English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
+
+公式 [Channel App SDK](https://github.com/channel-io/app-sdk) で作る最小構成の end-to-end App
+Store アプリです。Token exchange、Extension registration、signature verification、WAM bridge
+を独自実装せず、現在の SDK path を示します。
+
+この repository は実行可能な例として使い、contract と設計原則は SDK 文書を参照してください。
+
+- [アプリ開発完全ガイド](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ja/app-development.md)
+- [Function、Extension、WAM、認証の基本概念](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ja/concepts.md)
+- [Extension 完全ガイド](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ja/extensions.md)
+- [TypeScript authentication と token](https://github.com/channel-io/app-sdk/blob/main/docs/reference/typescript/AUTH-AND-TOKENS.md)
+- [TypeScript architecture](https://github.com/channel-io/app-sdk/blob/main/docs/reference/typescript/ARCHITECTURE.md)
+- [Command Extension](https://github.com/channel-io/app-sdk/blob/main/docs/reference/typescript/extensions/command.md)
+- [WAM SDK](https://github.com/channel-io/app-sdk/blob/main/docs/reference/typescript/WAM.md)
+
+## このアプリで確認できること
+
+- `@channel.io/app-sdk-server` と `@channel.io/app-sdk-wam` `0.17.2`
+- 自動 discovery/registration される `command` Extension
+- Zod input/output schema を持つ typed app Function
+- SDK-managed app/channel token cache と refresh
+- SDK signature guard による HMAC request verification
+- `@channel.io/app-sdk-wam` hook を使う React WAM
+- Server と WAM が共有する Zod contract package
+- `@channel.io/bezier-react/beta` の Bezier 4 component
+- AppStore が送る nullable command field の normalization
+
+Group chat で `/tutorial` Desk command を実行すると WAM が開きます。WAM は app bot を使う
+server-side app Function、または現在の manager authorization を使う WAM native Function で
+team-chat message を送信します。対応しない chat type では silent close せず error state を表示します。
+
+コード上の基本概念は次の要素に対応します。
+
+- **Extension**: `CommandExtension` が versioned `command` capability metadata を公開します。
+- **Function**: `tutorial.open` と `tutorial.sendAsBot` は command と WAM が参照する standalone typed operation です。
+- **WAM**: React UI は `/resource/wam/tutorial` で配信します。`useCallFunction` は app server、`useNativeFunction` は現在の manager として Channel を呼びます。
+- **認証**: `SignatureGuard` が inbound request を検証し、`TokenManager` が bot path の channel token を cache します。Server は許可済み group target に短期 signature を付けて WAM に渡し、manager authorization は Channel host が管理します。
+
+## SDK contract
+
+この tutorial は public SDK runtime contract に従います。
+
+- NestJS と `ChannelAppModule`
+- Decorator と schema を持つ Function
+- `PUT /functions/:version` と command の `/functions/v1`
+- SDK/AppStore による Extension discovery と registration
+- System version がない `PUT /functions` を同じ signature verification を使う `v1` handler に接続する限定的な compatibility mapping
+
+Reproducible build のため SDK `0.17.2` を固定し、app process 起動時に auto-registration を
+実行します。WAM は public SDK hook と Bezier API だけを使います。
+
+## 前提条件
+
+- Node.js 20.11 以上
+- Corepack 経由の pnpm 9.15.4
+- App ID、App Secret、Signing Key を持つ開発用 private Channel App
+
+アプリがまだない場合は SDK の
+[private app 準備手順](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ja/app-development.md#実装前に-private-app-を準備する)
+に従い、app creation、server-side credential storage、minimum permission、endpoint root、
+test channel installation を先に完了してください。
+
+**Authentication and permissions** で次の permission を有効にします。
+
+- Channel: `writeGroupMessage`
+- Manager: `writeGroupMessageAsManager`
+
+## 環境変数
+
+```sh
+cp server/.env.example server/.env
+```
+
+`APP_ID`、`APP_SECRET`、hex-encoded `SIGNING_KEY` を入力します。Secret を Git に commit しないでください。
+
+## HTTPS endpoint
+
+Local port `3000` に接続する HTTPS tunnel を準備し、developer portal に次の root を保存します。
+
+- Function Endpoint: `https://YOUR_HOST/functions`
+- WAM Endpoint: `https://YOUR_HOST/resource/wam`
+
+`/v1` や `/tutorial` を追加しません。Credential、permission、endpoint を server 起動後に
+変更した場合は、auto-registration を再実行するため server を restart してください。
+
+SDK route は versioned path を使います。現在の command execution は system version なしで
+設定済み Function Endpoint を呼ぶ場合があるため、tutorial は bare `PUT /functions` も同じ
+`/functions/v1` SDK handler と signature verification に接続します。
+
+## Install と build
+
+```sh
+corepack pnpm install --frozen-lockfile
+corepack pnpm build
+corepack pnpm test
+corepack pnpm typecheck
+```
+
+## 実行
+
+```sh
+corepack pnpm start
+```
+
+| Setting           | URL                                           |
+| ----------------- | --------------------------------------------- |
+| Function Endpoint | `https://YOUR_HOST/functions`                 |
+| WAM Endpoint      | `https://YOUR_HOST/resource/wam`              |
+| Local WAM         | `http://localhost:3000/resource/wam/tutorial` |
+
+Server startup と Extension registration が成功したら、test channel で private app を install
+または refresh し、group chat で `/tutorial` を実行してください。2 つの sender button と
+permission failure を確認します。`SKIP_SIGNATURE_VERIFICATION=true` は local debugging 以外で
+使用しないでください。
+
+## Project map
+
+```text
+server/
+  src/app.module.ts          SDK module、auto-registration、signature guard
+  src/function-endpoint.ts   bare Function Endpoint から v1 への mapping
+  src/tutorial.functions.ts command metadata と typed app Function
+  src/target-token.ts        bot path 用の短期 signed group target
+packages/shared/
+  src/index.ts               WAM data と app/native Function wire contract
+wam/
+  src/hooks/                 shared Zod contract で host data を validation
+  src/pages/Send/Send.tsx    app/native call 用 WAM SDK hook
+```
+
+この tutorial と旧 Web 文書が異なる場合は、public SDK export、SDK reference、SDK guide、この
+実行例の順で確認してください。SDK 文書も complete server/WAM example が必要な場合にこの
+tutorial を参照します。

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,134 @@
+# Channel App 튜토리얼 — TypeScript
+
+[English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
+
+공식 [Channel App SDK](https://github.com/channel-io/app-sdk)로 만든 최소 end-to-end App Store
+앱입니다. Token 교환, Extension 등록, signature 검증, WAM bridge를 직접 구현하지 않고 현재 SDK
+사용법을 보여 줍니다.
+
+이 저장소는 바로 실행할 수 있는 예제로 사용하고 계약과 설계 원칙은 SDK 문서를 확인하세요.
+
+- [앱 개발 전체 가이드](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ko/app-development.md)
+- [Function, Extension, WAM, 인증 핵심 개념](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ko/concepts.md)
+- [Extension 전체 가이드](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ko/extensions.md)
+- [TypeScript 인증과 token](https://github.com/channel-io/app-sdk/blob/main/docs/reference/typescript/AUTH-AND-TOKENS.md)
+- [TypeScript architecture](https://github.com/channel-io/app-sdk/blob/main/docs/reference/typescript/ARCHITECTURE.md)
+- [Command Extension](https://github.com/channel-io/app-sdk/blob/main/docs/reference/typescript/extensions/command.md)
+- [WAM SDK](https://github.com/channel-io/app-sdk/blob/main/docs/reference/typescript/WAM.md)
+
+## 이 앱에서 확인할 수 있는 것
+
+- `@channel.io/app-sdk-server`와 `@channel.io/app-sdk-wam` `0.17.2`
+- 자동 탐색·등록되는 `command` Extension
+- Zod input/output schema를 가진 typed app Function
+- SDK가 관리하는 app/channel token cache와 refresh
+- SDK signature guard를 통한 HMAC 요청 검증
+- `@channel.io/app-sdk-wam` hook을 사용하는 React WAM
+- Server와 WAM이 함께 쓰는 Zod contract package
+- `@channel.io/bezier-react/beta`의 Bezier 4 component
+- AppStore가 전달할 수 있는 nullable command field 정규화
+
+그룹 대화에서 `/tutorial` Desk command를 실행하면 WAM이 열립니다. WAM은 app bot을 사용하는
+server-side app Function 또는 현재 manager 권한을 사용하는 WAM native Function으로 team chat
+message를 보냅니다. 지원하지 않는 chat type에서는 조용히 닫지 않고 오류 상태를 보여 줍니다.
+
+코드에서 핵심 개념은 다음과 대응합니다.
+
+- **Extension**: `CommandExtension`이 versioned `command` capability metadata를 공개합니다.
+- **Function**: `tutorial.open`과 `tutorial.sendAsBot`은 command와 WAM이 참조하는 standalone typed operation입니다.
+- **WAM**: React UI는 `/resource/wam/tutorial`에서 제공됩니다. `useCallFunction`은 app server를, `useNativeFunction`은 현재 manager 주체로 Channel을 호출합니다.
+- **인증**: `SignatureGuard`가 수신 요청을 검증하고 `TokenManager`가 bot 경로의 channel token을 cache합니다. Server는 허용된 group target에 짧은 signature를 붙여 WAM에 전달하며 manager authorization은 Channel host가 관리합니다.
+
+## SDK 계약
+
+이 튜토리얼은 공개 SDK runtime 계약을 따릅니다.
+
+- NestJS와 `ChannelAppModule`
+- Decorator와 schema가 있는 Function
+- `PUT /functions/:version`과 command의 `/functions/v1`
+- SDK/AppStore를 통한 Extension discovery와 등록
+- System version이 없는 `PUT /functions` 요청을 같은 signature 검증이 적용되는 `v1` handler로 연결하는 좁은 compatibility mapping
+
+재현 가능한 build를 위해 SDK `0.17.2`를 고정하고 app process 시작 시 auto-registration을
+실행합니다. WAM은 공개 SDK hook과 Bezier API만 사용합니다.
+
+## 준비 사항
+
+- Node.js 20.11 이상
+- Corepack을 통한 pnpm 9.15.4
+- App ID, App Secret, Signing Key가 있는 개발용 private Channel App
+
+앱이 아직 없다면 SDK의
+[private app 준비 순서](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ko/app-development.md#구현-전에-private-app-준비하기)에
+따라 앱 생성, server-side credential 보관, 최소 permission, endpoint root, test channel 설치를
+먼저 완료하세요.
+
+**인증 및 권한** 설정에서 다음 permission을 활성화합니다.
+
+- Channel: `writeGroupMessage`
+- Manager: `writeGroupMessageAsManager`
+
+## 환경 변수
+
+```sh
+cp server/.env.example server/.env
+```
+
+`APP_ID`, `APP_SECRET`, hex-encoded `SIGNING_KEY`를 입력합니다. Secret을 Git에 commit하지 마세요.
+
+## HTTPS endpoint
+
+Local port `3000`을 연결하는 HTTPS tunnel을 준비하고 개발자 포털에 다음 root를 저장합니다.
+
+- Function Endpoint: `https://YOUR_HOST/functions`
+- WAM Endpoint: `https://YOUR_HOST/resource/wam`
+
+`/v1`이나 `/tutorial`을 덧붙이지 않습니다. Credential, permission, endpoint를 server 시작 뒤
+바꿨다면 auto-registration이 다시 실행되도록 server를 재시작하세요.
+
+SDK route는 versioned path를 사용합니다. 현재 command execution은 system version 없이 설정된
+Function Endpoint를 호출할 수 있으므로 튜토리얼은 bare `PUT /functions`도 같은
+`/functions/v1` SDK handler와 signature 검증으로 연결합니다.
+
+## 설치와 build
+
+```sh
+corepack pnpm install --frozen-lockfile
+corepack pnpm build
+corepack pnpm test
+corepack pnpm typecheck
+```
+
+## 실행
+
+```sh
+corepack pnpm start
+```
+
+| 설정              | URL                                           |
+| ----------------- | --------------------------------------------- |
+| Function Endpoint | `https://YOUR_HOST/functions`                 |
+| WAM Endpoint      | `https://YOUR_HOST/resource/wam`              |
+| Local WAM         | `http://localhost:3000/resource/wam/tutorial` |
+
+Server가 시작되고 Extension 등록이 성공하면 test channel에서 private app을 설치하거나 새로고침한
+뒤 그룹 대화에서 `/tutorial`을 실행하세요. 두 sender button과 permission failure를 모두
+확인합니다. `SKIP_SIGNATURE_VERIFICATION=true`는 local debugging 밖에서 사용하지 마세요.
+
+## 프로젝트 구조
+
+```text
+server/
+  src/app.module.ts          SDK module, auto-registration, signature guard
+  src/function-endpoint.ts   bare Function Endpoint to v1 mapping
+  src/tutorial.functions.ts command metadata와 typed app Function
+  src/target-token.ts        bot 경로용 짧은 수명의 signed group target
+packages/shared/
+  src/index.ts               WAM data와 app/native Function wire contract
+wam/
+  src/hooks/                 shared Zod contract로 host data 검증
+  src/pages/Send/Send.tsx    app/native call용 WAM SDK hook
+```
+
+이 튜토리얼과 오래된 웹 문서가 다르면 공개 SDK export, SDK reference, SDK guide, 이 실행 예제
+순서로 확인하세요. SDK 문서도 완성된 server/WAM 예제가 필요할 때 이 튜토리얼을 연결합니다.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,28 @@
 # Channel App tutorial — TypeScript
 
+[English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
+
 A minimal Channel App Store app built with the official
-[Channel App SDK](https://github.com/channel-io/cht-app-sdk). It demonstrates the current SDK path
+[Channel App SDK](https://github.com/channel-io/app-sdk). It demonstrates the current SDK path
 instead of implementing token exchange, extension registration, signature verification, and WAM
 bindings by hand.
 
 Use this repository for a runnable end-to-end app. Use the SDK repository for the API contract and
 design guidance:
 
-- [English app-development guide](https://github.com/channel-io/cht-app-sdk/blob/main/docs/guides/en/app-development.md)
-- [English concepts: Function, Extension, WAM, and authentication](https://github.com/channel-io/cht-app-sdk/blob/main/docs/guides/en/concepts.md)
-- [한국어 앱 개발 전체 가이드](https://github.com/channel-io/cht-app-sdk/blob/main/docs/guides/ko/app-development.md)
-- [한국어 핵심 개념](https://github.com/channel-io/cht-app-sdk/blob/main/docs/guides/ko/concepts.md)
-- [日本語アプリ開発完全ガイド](https://github.com/channel-io/cht-app-sdk/blob/main/docs/guides/ja/app-development.md)
-- [日本語の基本概念](https://github.com/channel-io/cht-app-sdk/blob/main/docs/guides/ja/concepts.md)
-- [Authentication and tokens](https://github.com/channel-io/cht-app-sdk/blob/main/docs/reference/typescript/AUTH-AND-TOKENS.md)
-- [TypeScript architecture](https://github.com/channel-io/cht-app-sdk/blob/main/docs/reference/typescript/ARCHITECTURE.md)
-- [Command extension](https://github.com/channel-io/cht-app-sdk/blob/main/docs/reference/typescript/extensions/command.md)
-- [WAM SDK](https://github.com/channel-io/cht-app-sdk/blob/main/docs/reference/typescript/WAM.md)
+- [English app-development guide](https://github.com/channel-io/app-sdk/blob/main/docs/guides/en/app-development.md)
+- [English concepts: Function, Extension, WAM, and authentication](https://github.com/channel-io/app-sdk/blob/main/docs/guides/en/concepts.md)
+- [English Extension guide](https://github.com/channel-io/app-sdk/blob/main/docs/guides/en/extensions.md)
+- [한국어 앱 개발 전체 가이드](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ko/app-development.md)
+- [한국어 핵심 개념](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ko/concepts.md)
+- [한국어 Extension 전체 가이드](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ko/extensions.md)
+- [日本語アプリ開発完全ガイド](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ja/app-development.md)
+- [日本語の基本概念](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ja/concepts.md)
+- [日本語 Extension 完全ガイド](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ja/extensions.md)
+- [Authentication and tokens](https://github.com/channel-io/app-sdk/blob/main/docs/reference/typescript/AUTH-AND-TOKENS.md)
+- [TypeScript architecture](https://github.com/channel-io/app-sdk/blob/main/docs/reference/typescript/ARCHITECTURE.md)
+- [Command extension](https://github.com/channel-io/app-sdk/blob/main/docs/reference/typescript/extensions/command.md)
+- [WAM SDK](https://github.com/channel-io/app-sdk/blob/main/docs/reference/typescript/WAM.md)
 
 ## What this app demonstrates
 
@@ -42,20 +47,19 @@ Concepts in this repository map to concrete code as follows:
 - **WAM**: the React UI is served at `/resource/wam/tutorial`; `useCallFunction` calls the app server and `useNativeFunction` acts as the current manager.
 - **Authentication**: `SignatureGuard` verifies inbound requests, `TokenManager` caches the channel token used by the bot path, the server signs the allowed group-chat target before giving it to the WAM, and the Channel host owns manager authorization.
 
-## Runtime contract alignment
+## SDK contract alignment
 
-Managed builders and this tutorial use the same public runtime contract:
+This tutorial follows the public SDK runtime contract:
 
 - NestJS with `ChannelAppModule`
 - decorated, schema-backed functions
 - `PUT /functions/:version` (`/functions/v1` for the command extension)
 - extension discovery and registration through the SDK/AppStore
-- a narrow ingress compatibility mapping from bare `PUT /functions` calls to `v1`, matching the
-  managed runtime gateway used when the caller does not carry a system version
+- a narrow ingress compatibility mapping from bare `PUT /functions` calls to the same verified
+  `v1` handler when the caller does not carry a system version
 
-A managed builder may select the SDK version and own deployment, endpoint sync, and post-deploy
-extension registration. This standalone tutorial pins `0.17.2` for reproducible builds and enables
-SDK auto-registration in the app process. Its WAM uses only public SDK hooks and Bezier APIs.
+This tutorial pins `0.17.2` for reproducible builds and enables SDK auto-registration in the app
+process. Its WAM uses only public SDK hooks and Bezier APIs.
 
 ## Prerequisites
 
@@ -64,7 +68,7 @@ SDK auto-registration in the app process. Its WAM uses only public SDK hooks and
 - a private Channel App with an App ID, App Secret, and Signing Key
 
 If you do not have an app yet, follow the SDK's
-[private-app preparation sequence](https://github.com/channel-io/cht-app-sdk/blob/main/docs/guides/en/app-development.md#prepare-a-private-app-before-coding): create a development app, keep credentials server-side, enable the minimum permissions below, prepare endpoint roots, and install it in a test channel.
+[private-app preparation sequence](https://github.com/channel-io/app-sdk/blob/main/docs/guides/en/app-development.md#prepare-a-private-app-before-coding): create a development app, keep credentials server-side, enable the minimum permissions below, prepare endpoint roots, and install it in a test channel.
 
 Enable these permissions in the app's **Authentication and permissions** settings:
 
@@ -92,7 +96,7 @@ server starts, restart the server so auto-registration runs again.
 
 The SDK route itself remains versioned. The tutorial also accepts bare `PUT /functions` and maps it
 to `/functions/v1` because current command execution can call the configured Function Endpoint
-without a system-version suffix. Managed runtimes provide the same mapping at their ingress.
+without a system-version suffix. Both paths reuse the same SDK handler and signature verification.
 
 ## Install and build
 

--- a/wam/README.ja.md
+++ b/wam/README.ja.md
@@ -1,0 +1,43 @@
+# WAM
+
+[English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
+
+この React frontend は WAM bridge に
+[`@channel.io/app-sdk-wam`](https://github.com/channel-io/app-sdk/tree/main/ts/packages/wam)、
+WAM 専用 theme、navigation、state、高さ同期に
+[`@channel.io/app-sdk-wam-ui`](https://github.com/channel-io/app-sdk/tree/main/ts/packages/wam-ui)
+を使います。一般的な UI component は `@channel.io/bezier-react/beta` から直接 import します。
+
+Server と WAM はどちらも `@tutorial/shared` に依存します。Zod schema と inferred type により
+WAM data、app/native Function input、WAM name、Function name を一致させます。Secret、token、
+server-only runtime state を shared package に入れないでください。
+
+Example は Bezier React `4.0.0-next.13` と Bezier Icons `0.60.0` を固定します。Bezier React 4
+はまだ prerelease なので version を明示的に pin し、upgrade 前に
+[SDK WAM UI guide](https://github.com/channel-io/app-sdk/blob/main/docs/reference/typescript/WAM-UI.md)
+を確認してください。
+
+## Setup
+
+Node.js 20.11 以上を install し、Corepack で pnpm を有効にします。
+
+```sh
+corepack enable
+corepack prepare pnpm@9.15.4 --activate
+pnpm install --frozen-lockfile
+```
+
+Repository root で WAM development server を起動します。
+
+```sh
+pnpm dev:wam
+```
+
+すべての workspace を build します。
+
+```sh
+pnpm build
+```
+
+Build output は `wam/dist/` に生成され、tutorial server が
+`/resource/wam/tutorial` で配信します。

--- a/wam/README.ko.md
+++ b/wam/README.ko.md
@@ -1,0 +1,43 @@
+# WAM
+
+[English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
+
+이 React frontend는 WAM bridge에
+[`@channel.io/app-sdk-wam`](https://github.com/channel-io/app-sdk/tree/main/ts/packages/wam)을,
+WAM 전용 theme, navigation, 상태 화면, 높이 동기화에
+[`@channel.io/app-sdk-wam-ui`](https://github.com/channel-io/app-sdk/tree/main/ts/packages/wam-ui)를
+사용합니다. 일반 UI component는 `@channel.io/bezier-react/beta`에서 직접 가져옵니다.
+
+Server와 WAM은 모두 `@tutorial/shared`에 의존합니다. Zod schema와 inferred type이 WAM data,
+app/native Function input, WAM name, Function name을 일치시킵니다. Secret, token, server-only
+runtime state는 shared package에 넣지 않습니다.
+
+예제는 Bezier React `4.0.0-next.13`과 Bezier Icons `0.60.0`을 고정합니다. Bezier React 4는
+아직 prerelease이므로 버전을 명시적으로 고정하고 upgrade 전에
+[SDK WAM UI 가이드](https://github.com/channel-io/app-sdk/blob/main/docs/reference/typescript/WAM-UI.md)를
+확인하세요.
+
+## 설정
+
+Node.js 20.11 이상을 설치하고 Corepack으로 pnpm을 활성화합니다.
+
+```sh
+corepack enable
+corepack prepare pnpm@9.15.4 --activate
+pnpm install --frozen-lockfile
+```
+
+Repository root에서 WAM 개발 server를 실행합니다.
+
+```sh
+pnpm dev:wam
+```
+
+전체 workspace를 build합니다.
+
+```sh
+pnpm build
+```
+
+Build 결과는 `wam/dist/`에 생성되고 tutorial server가
+`/resource/wam/tutorial`에서 제공합니다.

--- a/wam/README.md
+++ b/wam/README.md
@@ -1,9 +1,11 @@
 # WAM
 
+[English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
+
 This React frontend uses
-[`@channel.io/app-sdk-wam`](https://github.com/channel-io/cht-app-sdk/tree/main/ts/packages/wam)
+[`@channel.io/app-sdk-wam`](https://github.com/channel-io/app-sdk/tree/main/ts/packages/wam)
 for the WAM bridge and
-[`@channel.io/app-sdk-wam-ui`](https://github.com/channel-io/cht-app-sdk/tree/main/ts/packages/wam-ui)
+[`@channel.io/app-sdk-wam-ui`](https://github.com/channel-io/app-sdk/tree/main/ts/packages/wam-ui)
 for WAM-specific theming, navigation, states, and content-height synchronization. Import
 general-purpose UI components directly from `@channel.io/bezier-react/beta`.
 
@@ -13,7 +15,7 @@ tokens, and server-only runtime state do not belong in the shared package.
 
 The example pins Bezier React `4.0.0-next.13` and Bezier Icons `0.60.0`. Bezier React 4 is still a
 prerelease, so keep the selected version explicit and check the
-[SDK WAM UI guide](https://github.com/channel-io/cht-app-sdk/blob/main/docs/reference/typescript/WAM-UI.md)
+[SDK WAM UI guide](https://github.com/channel-io/app-sdk/blob/main/docs/reference/typescript/WAM-UI.md)
 before upgrading it.
 
 ## Setup


### PR DESCRIPTION
## Summary
- switch SDK documentation links to channel-io/app-sdk
- add complete Korean and Japanese TypeScript tutorial READMEs
- add localized WAM setup guides and language navigation
- remove platform-specific runtime wording and link the localized Extension guides

## Test Plan
- [x] corepack pnpm install --frozen-lockfile
- [x] corepack pnpm build
- [x] corepack pnpm test
- [x] corepack pnpm typecheck
- [x] Prettier and Markdown target checks